### PR TITLE
Fix  'Could not find a package configuration file provided by "Eigen"…

### DIFF
--- a/but_velodyne_proc/CMakeLists.txt
+++ b/but_velodyne_proc/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin
   velodyne_pointcloud
   costmap_2d
   roslint
+  cmake_modules
 )
 
 find_package(PkgConfig REQUIRED)


### PR DESCRIPTION
Before:
```
CMake Error at but_velodyne/but_velodyne_proc/CMakeLists.txt:20 (find_package):
  By not providing "FindEigen.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Eigen", but
  CMake did not find one.

  Could not find a package configuration file provided by "Eigen" with any of
  the following names:

    EigenConfig.cmake
    eigen-config.cmake

  Add the installation prefix of "Eigen" to CMAKE_PREFIX_PATH or set
  "Eigen_DIR" to a directory containing one of the above files.  If "Eigen"
  provides a separate development package or SDK, be sure it has been
  installed.
```

After:
```
-- Found Eigen: /usr/include/eigen3  
-- Eigen found (include: /usr/include/eigen3)
```
